### PR TITLE
Fix parameter name in rm_empty_subdirs

### DIFF
--- a/docker/bin/rm_empty_subdirs
+++ b/docker/bin/rm_empty_subdirs
@@ -3,12 +3,12 @@
 import os
 
 def remove_empty_directories(initial_dir,
-    allow_initial_delete=False, ignore_nonexistant_initial=False,
+    allow_initial_delete=False, ignore_nonexistent_initial=False,
     dry_run=False, quiet=False):
 
     FORBIDDEN_SUBDIRS = set([".git"])
 
-    if not os.path.isdir(initial_dir) and not ignore_nonexistant_initial:
+    if not os.path.isdir(initial_dir) and not ignore_nonexistent_initial:
         raise RuntimeError("Initial directory '{}' not found!".format(initial_dir))
 
     message = "removed"


### PR DESCRIPTION
## Summary
- fix parameter typo `ignore_nonexistant_initial`

## Testing
- `python docker/bin/rm_empty_subdirs --help | head`

------
https://chatgpt.com/codex/tasks/task_e_68472ec0a5dc832587c0f36d0d9d9131