### PR TITLE
Check for checkpoint file in nbdiff_checkpoint

### DIFF
--- a/docker/bin/nbdiff_checkpoint
+++ b/docker/bin/nbdiff_checkpoint
@@ -13,5 +13,11 @@ shift
 WORKING_COPY=$DIRNAME/$BASENAME.ipynb
 CHECKPOINT_COPY=$DIRNAME/.ipynb_checkpoints/$BASENAME-checkpoint.ipynb
 
+# verify checkpoint file exists before calling nbdiff
+if [ ! -f "$CHECKPOINT_COPY" ]; then
+    echo "checkpoint not found: $CHECKPOINT_COPY" >&2
+    exit 1
+fi
+
 echo "----- Analysing how to change $CHECKPOINT_COPY into $WORKING_COPY -----"
 nbdiff "$CHECKPOINT_COPY" "$WORKING_COPY" --ignore-details "$@"


### PR DESCRIPTION
## Summary
- update `nbdiff_checkpoint` to validate that the checkpoint file exists

## Testing
- `bash docker/bin/nbdiff_checkpoint nonexistent.ipynb`

------
https://chatgpt.com/codex/tasks/task_e_68472ec4db048325851fc8cbe96e9f11